### PR TITLE
Updating stan code to the most recent syntax

### DIFF
--- a/vignettes/stan/discrete_vars1.stan
+++ b/vignettes/stan/discrete_vars1.stan
@@ -3,7 +3,7 @@ data {
   real<lower=0> r_l;
 
   int<lower=1> T;
-  int<lower=0> y[T];
+  array[T] int<lower=0> y;
 }
 transformed data {
   real log_unif;

--- a/vignettes/stan/poisson.stan
+++ b/vignettes/stan/poisson.stan
@@ -1,6 +1,6 @@
 data{
   int N;
-  int y[N];
+  array[N] int y;
 }
 parameters{
   real<lower = 0> lambda;

--- a/vignettes/stan/rejection_sampling.stan
+++ b/vignettes/stan/rejection_sampling.stan
@@ -1,6 +1,6 @@
 data {
    int<lower=0> N;
-   real y[N];
+   array[N] real y;
 }
 
 parameters {


### PR DESCRIPTION
I came across that the "Getting Started" ([https://hyunjimoon.github.io/SBC/articles/SBC.html](https://hyunjimoon.github.io/SBC/articles/SBC.html)) uses old stan syntax for declaring arrays.

Old syntax:
```
data{   
  int N; 
  int y[N];
}
```

New syntax:
```
data{
  int N;
  array[N] int y;
}
```

I checked all the files in [https://github.com/hyunjimoon/SBC/tree/master/vignettes/stan](https://github.com/hyunjimoon/SBC/tree/master/vignettes/stan) and updated the syntax according to [https://mc-stan.org/docs/reference-manual/types.html#array-data-types.section](https://mc-stan.org/docs/reference-manual/types.html#array-data-types.section).