### PR TITLE
separate ecdf_alpha logic from combine

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -466,22 +466,21 @@ data_for_ecdf_plots.matrix <- function(x,
   ecdf_df$..z <- z
   ecdf_df <- tidyr::pivot_longer(ecdf_df, -..z, names_to = "variable", values_to = "ecdf")
   ecdf_df <- dplyr::rename(ecdf_df, z = ..z)
-  # Allow user-specified grouping of variables (issue #88)
-
+  # Allow user-specified grouping of variables + alpha on ecdf line (issue #88)
+  if(is.null(ecdf_alpha)) {
+    ecdf_alpha <- \(x) sqrt(1/x)
+  } else if(is.numeric(ecdf_alpha) & length(ecdf_alpha) == 1) {
+    ecdf_alpha_numeric <- ecdf_alpha
+    ecdf_alpha <- \(x) ecdf_alpha_numeric
+  } else if(!is.function(ecdf_alpha) | nargs(ecdf_alpha) != 1) {
+    stop("`ecdf_alpha` must be a function taking a single argument or a single numerical value")
+  }
   if (!is.null(combine_variables)) {
     if(is.function(combine_variables)) {
       combine_variables <- combine_variables(unique(ecdf_df$variable))
     }
     if(!is.list(combine_variables) | is.null(names(combine_variables))) {
       stop("`combine_variables` must be a named list or a function returning a named list")
-    }
-    if(is.null(ecdf_alpha)) {
-      ecdf_alpha <- \(x) sqrt(1/x)
-    } else if(is.numeric(ecdf_alpha) & length(ecdf_alpha) == 1) {
-      ecdf_alpha_numeric <- ecdf_alpha
-      ecdf_alpha <- \(x) ecdf_alpha_numeric
-    } else if(!is.function(ecdf_alpha) | nargs(ecdf_alpha) != 1) {
-      stop("`ecdf_alpha` must be a function taking a single argument or a single numerical value")
     }
 
     if(!identical(unique(table(unlist(combine_variables))), 1L)) {


### PR DESCRIPTION
Thought about setting line 501 to ` ecdf_df$alpha <- 1` to restore old functionality, but I suppose we now want the argument to work independently of `combine` for more customization.

Taking the `ecdf_alpha` checks outside of the `if` branch for `combine` seems sensible in this case.