### PR TITLE
Warn user if brms prior is left unspecified 

### DIFF
--- a/R/generator-brms.R
+++ b/R/generator-brms.R
@@ -33,6 +33,10 @@ SBC_generator_brms <- function(formula, data, ...,  generate_lp = TRUE,
     }
   }
 
+  if(is.null(args$prior)) {
+    warning("The `prior` argument was not specified and brms defaults will be used. It is unlikely this will produce usable datasets.")
+  }
+
   compiled_model <- stanmodel_for_brms(formula = formula, data = data, out_stan_file = out_stan_file, ...)
 
 


### PR DESCRIPTION
Should prevent confusing errors like the one in #116 